### PR TITLE
Linked List 04: Rename push function

### DIFF
--- a/LinkedLists/LinkedList.php
+++ b/LinkedLists/LinkedList.php
@@ -62,7 +62,7 @@ class LinkedList
      *
      * @param int $data
      */
-    public function push(int $data): void {
+    public function insertAtTheBeginning(int $data): void {
         $newNode = new Node($data);
         $newNode->next = $this->head;
         $this->head = $newNode;


### PR DESCRIPTION
As the other functions responsible to insert elements to the linked lists has the patter 'insert' as the first word of its name, we updated this function to reflect this pattern. So we renamed it from 'push' to 'insertAtTheBeginning'. The implementation remains the same.