### PR TITLE
BUGFIX 01: CircleCI Startup fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/php:7.1.5-browsers
+      - image: circleci/php:7.1-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
When building the project in CircleCI, the startup process fails due the missing of composer in the image which was being used by the CI. So, we downgrade the image version from 7.1.5 to 7.1. This a little older version has composer embedded.