### PR TITLE
Bugfix 02: Removing php command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,3 @@ jobs:
           paths:
             - ./vendor
           key: v1-dependencies-{{ checksum "composer.json" }}
-
-      # run tests!
-      - run: phpunit


### PR DESCRIPTION
As we did not have any PHPUnit test so far, there is no need to keep the command in config.yml file. This will avoid the error of phpunit not found on image.